### PR TITLE
build: do not execute checks against generated code

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,15 +48,17 @@ subprojects {
         useJUnitPlatform()
     }
 
+    val generatedFilesFolder = "build${File.separator}generated"
+
     tasks.withType<SourceTask>()
         .matching { it is VerificationTask }
         .configureEach {
-            exclude { "generated" in it.file.absolutePath }
+            exclude { generatedFilesFolder in it.file.absolutePath }
         }
 
     ktlint {
         filter {
-            exclude { "build${File.separator}generated" in it.file.absolutePath }
+            exclude { generatedFilesFolder in it.file.absolutePath }
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,9 +22,7 @@ subprojects {
     with(rootProject.libs.plugins) {
         apply(plugin = "java-library")
         apply(plugin = kotlin.jvm.get().pluginId)
-        if (name != "presentation") {
-            apply(plugin = kotlin.qa.get().pluginId)
-        }
+        apply(plugin = kotlin.qa.get().pluginId)
         apply(plugin = kotlin.dokka.get().pluginId)
     }
 
@@ -48,5 +46,17 @@ subprojects {
             exceptionFormat = TestExceptionFormat.FULL
         }
         useJUnitPlatform()
+    }
+
+    tasks.withType<SourceTask>()
+        .matching { it is VerificationTask }
+        .configureEach {
+            exclude { "generated" in it.file.absolutePath }
+        }
+
+    ktlint {
+        filter {
+            exclude { "build${File.separator}generated" in it.file.absolutePath }
+        }
     }
 }

--- a/grpc/build.gradle.kts
+++ b/grpc/build.gradle.kts
@@ -1,7 +1,3 @@
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     api(project(":presentation"))
     with(libs) {

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -1,15 +1,5 @@
-import de.aaschmid.gradle.plugins.cpd.Cpd
-import io.gitlab.arturbosch.detekt.Detekt
-import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.gradle.api.tasks.testing.logging.TestLogEvent
-
 plugins {
     alias(libs.plugins.protobuf)
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {
@@ -22,18 +12,9 @@ dependencies {
     }
 }
 
-
-tasks.withType<Test>().configureEach {
-    testLogging {
-        events(*TestLogEvent.values())
-        exceptionFormat = TestExceptionFormat.FULL
-    }
-    useJUnitPlatform()
+tasks.named("cpdKotlinCheck") {
+    dependsOn(tasks.named("generateProto"))
 }
-
-// tasks.named("cpdKotlinCheck") {
-//     dependsOn(tasks.named("generateProto"))
-// }
 
 protobuf {
     protoc {


### PR DESCRIPTION
This solves #38 

The reason why ktlint exclusion didn't work is explained [here](https://github.com/JLLeitschuh/ktlint-gradle/issues/222#issuecomment-480755054)